### PR TITLE
HW11

### DIFF
--- a/test/java/HW10/CheckBox.java
+++ b/test/java/HW10/CheckBox.java
@@ -3,6 +3,9 @@ package HW10;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.*;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -23,8 +26,10 @@ public class CheckBox {
     }
 
     @Test
-    public void checkboxCheck() throws InterruptedException {
-        driver = new ChromeDriver();
+    public void checkboxCheck() {
+        ChromeOptions options = new ChromeOptions();
+        options.setAcceptInsecureCerts(true);
+        driver = new ChromeDriver(options);
         driver.manage().window().maximize();
         driver.get("https://demoqa.com/checkbox");
 
@@ -32,10 +37,8 @@ public class CheckBox {
         JavascriptExecutor jsExecutor = (JavascriptExecutor) driver;
         jsExecutor.executeScript("arguments[0].parentNode.removeChild(arguments[0])", trash);
 
-        WebElement expandAll = driver.findElement(By.xpath("//*[@class = 'rct-option rct-option-expand-all']"));
-        ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView(true);", expandAll);
-        Thread.sleep(500);
-        expandAll.click();
+        WebDriverWait expandAll = new WebDriverWait(driver, 30);
+        expandAll.until(ExpectedConditions.elementToBeClickable(By.xpath("//*[@class = 'rct-option rct-option-expand-all']"))).click();
 
         Assert.assertEquals(driver.findElement(By.id("tree-node-wordFile")).isSelected(), false) ;
         Assert.assertEquals(driver.findElement(By.id("tree-node-excelFile")).isSelected(), false) ;

--- a/test/java/HW10/ClickTest.java
+++ b/test/java/HW10/ClickTest.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.interactions.Actions;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -15,6 +16,7 @@ import org.testng.annotations.Test;
 public class ClickTest
 {
     WebDriver driver;
+
 
     @BeforeMethod
     public void setup()
@@ -29,8 +31,11 @@ public class ClickTest
     }
 
     @Test
-    public void testDoubleClick() throws InterruptedException {
-        driver = new ChromeDriver();
+    public void testDoubleClick() {
+        ChromeOptions options = new ChromeOptions();
+        options.setAcceptInsecureCerts(true);
+        driver = new ChromeDriver(options);
+        driver.manage().window().maximize();
         driver.get("https://demoqa.com/buttons");
 
         WebElement trash = driver.findElement(By.id("fixedban"));
@@ -40,12 +45,11 @@ public class ClickTest
         Actions actions = new Actions(driver);
         WebElement button = driver.findElement(By.id("doubleClickBtn"));
         ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView(true);", button);
-        Thread.sleep(500);
         actions.doubleClick(button).perform();
         Assert.assertEquals(driver.findElement(By.id("doubleClickMessage")).isDisplayed(), true);
     }
         @Test
-        public void testRigtClick() throws InterruptedException {
+        public void testRigtClick() {
             driver = new ChromeDriver();
             driver.get("https://demoqa.com/buttons");
 
@@ -56,13 +60,12 @@ public class ClickTest
             Actions actions = new Actions(driver);
             WebElement button = driver.findElement(By.id("rightClickBtn"));
             ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView(true);", button);
-            Thread.sleep(500);
             actions.contextClick(button).perform();
             Assert.assertEquals(driver.findElement(By.id("rightClickMessage")).isDisplayed(), true);
         }
 
         @Test
-        public void testDynamicClick () throws InterruptedException {
+        public void testDynamicClick () {
             driver = new ChromeDriver();
             driver.get("https://demoqa.com/buttons");
 
@@ -73,7 +76,6 @@ public class ClickTest
             Actions actions = new Actions(driver);
             WebElement button = driver.findElement(By.cssSelector(".mt-4 > button:not(#rightClickBtn.btn.btn-primary)"));
             ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView(true);", button);
-            Thread.sleep(500);
             actions.click(button).perform();
             Assert.assertEquals(driver.findElement(By.id("dynamicClickMessage")).isDisplayed(), true);
         }

--- a/test/java/HW11/DownloadUpload.java
+++ b/test/java/HW11/DownloadUpload.java
@@ -1,0 +1,76 @@
+package HW11;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class DownloadUpload
+{
+    WebDriver driver;
+
+    @BeforeMethod
+    public void setup() {
+        WebDriverManager.chromedriver().setup();
+    }
+
+    @AfterMethod
+    public void teardown() {
+        File dir = new File("target\\dowloaded files");
+        for (File file:dir.listFiles()) {
+            file.delete();
+        }
+        dir.delete();
+        driver.quit();
+    }
+
+    @Test
+    public void loadTest() throws InterruptedException {
+        ChromeOptions options = new ChromeOptions();
+        options.setAcceptInsecureCerts(true);
+
+        Map<String, Object> prefs = new HashMap<String, Object>();
+        prefs.put("download.default_directory", Paths.get("target\\dowloaded files").toFile().getAbsolutePath());
+        prefs.put("safebrowsing.enabled", "false");
+        prefs.put("profile.default_content_settings.popups", 0);
+
+        options.setExperimentalOption("prefs", prefs);
+        driver = new ChromeDriver(options);
+        driver.manage().window().maximize();
+        driver.get("https://demoqa.com/upload-download");
+
+        WebElement trash = driver.findElement(By.id("fixedban"));
+        JavascriptExecutor jsExecutor = (JavascriptExecutor) driver;
+        jsExecutor.executeScript("arguments[0].parentNode.removeChild(arguments[0])", trash);
+
+        WebElement download = driver.findElement(By.id("downloadButton"));
+        ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView(true);", download);
+        download.click();
+
+        driver.manage().timeouts().pageLoadTimeout(100, SECONDS);
+
+        File file = new File("target\\dowloaded files");
+        System.out.println(file.getAbsolutePath());
+
+        WebElement upload = driver.findElement(By.id("uploadFile"));
+        ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView(true);", upload);
+        upload.sendKeys(file.getAbsolutePath());
+
+        Assert.assertEquals(driver.findElement(By.id("uploadedFilePath")).isDisplayed(), true);
+
+    }
+}

--- a/test/java/HW11/FileTest.java
+++ b/test/java/HW11/FileTest.java
@@ -1,0 +1,28 @@
+package HW11;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.openqa.selenium.WebDriver;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+public class FileTest
+{
+    @Test
+    public void fileGenerate()
+    {
+        File file = new File("target", "fileTest.txt");
+        try {
+            file.createNewFile();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        System.out.println(file.getName());
+        System.out.println(file.getAbsolutePath());
+        file.delete(); //удаление файла сделано исключительно для локального теста, чтоб не очищать target после каждого теста
+
+    }
+}


### PR DESCRIPTION
Использовать повсеместно WebDriverWait вместо Thread.sleep не могу, так как практически все тесты работают через JSExecutor со скриптом scrollIntoView. Данное решение обусловлено тем, что на моей системе имеются проблемы с сайтом demoqa.com
В частности, веб-драйвер не может загрузить css файл с bootstrapcdn.com (Error504), от чего вся вёрстка съезжает и элементы перекрывают друг друга. Пример: [https://prnt.sc/21lk5ff](url)
При использовании ExpectedConditions.elementToBeClickable тесты падают с ошибкой "Элемент не кликабелен, иной элемент перехватывает клик <footer>..."

